### PR TITLE
Stopped duplicates from adding to collections when editing photo information

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -59,6 +59,6 @@ class CollectionsController < ApplicationController
   private
 
   def collection_params
-    params.require(:collection).permit(:name, :description)
+    params.require(:collection).permit(:name, :description, :cover)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -32,9 +32,13 @@ class CollectionsController < ApplicationController
     @bookmarks = Bookmark.all.select { |bookmark| bookmark.collection_id = @collection.id}
   end
 
-  def editing
-    @collection = Collection.find(params[:collect_id])
+  def edit
+    @collection = Collection.find(params[:id])
     authorize @collection
+    @cover = []
+    @collection.photos.each_with_index do |item, i|
+      @cover << ["#{item.title}", "#{i}"]
+    end
   end
 
   def update

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -50,9 +50,11 @@ class PhotosController < ApplicationController
       params[:photo][:collection_ids].delete("")
       params[:photo][:collection_ids].each do |collection|
         @bookmark = Bookmark.new(photo: @photo, collection_id: collection)
+        if !@photo.bookmarks.any? { |bookmark| bookmark.photo_id == @bookmark.photo_id && bookmark.collection_id == @bookmark.collection_id }
         @bookmark.save!
-        redirect_to photo_path(@photo)
+        end
       end
+      redirect_to photo_path(@photo)
     else
       render :new
     end

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,8 +1,13 @@
 <h1>Edit Album Title or Description</h1>
 <% @collection = Collection.find(params[:id]) %>
+<% arr = [] %>
+<% @collection.photos.each_with_index do |item, i| %>
+  <% arr << ["#{item.title}", "#{i}"] %>
+<% end %>
 <%= simple_form_for @collection do |f| %>
   <%= f.input :name %>
    <%= f.input :description %>
+  <%= f.input :cover, collection: arr %>
   <%= f.button :submit, "Update" %>
 <% end %>
 

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,13 +1,8 @@
 <h1>Edit Album Title or Description</h1>
-<% @collection = Collection.find(params[:id]) %>
-<% arr = [] %>
-<% @collection.photos.each_with_index do |item, i| %>
-  <% arr << ["#{item.title}", "#{i}"] %>
-<% end %>
 <%= simple_form_for @collection do |f| %>
   <%= f.input :name %>
    <%= f.input :description %>
-  <%= f.input :cover, collection: arr %>
+  <%= f.input :cover, collection: @cover %>
   <%= f.button :submit, "Update" %>
 <% end %>
 

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -4,7 +4,6 @@
   <% if collection.cover != nil %>
     <%= cl_image_tag collection.photos[collection.cover].photo.key, height: 100, width: 100 %>
   <% else %>
-    <%# <%= cl_image_tag collection.photos[0].photo.key, height: 100, width: 100 %>
     <span>No cover image selected</span>
   <% end %>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -4,6 +4,7 @@
   <% if collection.cover != nil %>
     <%= cl_image_tag collection.photos[collection.cover].photo.key, height: 100, width: 100 %>
   <% else %>
-    <%= cl_image_tag collection.photos[0].photo.key, height: 100, width: 100 %>
+    <%# <%= cl_image_tag collection.photos[0].photo.key, height: 100, width: 100 %>
+    <span>No cover image selected</span>
   <% end %>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -1,4 +1,9 @@
 <h1>All collections</h1>
 <% @collections.each do |collection| %>
- <%=  link_to collection.name, collection_path(collection.id) %>
+  <%= link_to collection.name, collection_path(collection.id) %>
+  <% if collection.cover != nil %>
+    <%= cl_image_tag collection.photos[collection.cover].photo.key, height: 100, width: 100 %>
+  <% else %>
+    <%= cl_image_tag collection.photos[0].photo.key, height: 100, width: 100 %>
+  <% end %>
 <% end %>

--- a/db/migrate/20221018133653_add_cover_to_collections.rb
+++ b/db/migrate/20221018133653_add_cover_to_collections.rb
@@ -1,0 +1,5 @@
+class AddCoverToCollections < ActiveRecord::Migration[7.0]
+  def change
+    add_column :collections, :cover, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_15_110659) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_18_133653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_15_110659) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "photo_id"
+    t.integer "cover"
     t.index ["photo_id"], name: "index_collections_on_photo_id"
   end
 


### PR DESCRIPTION
Now when you edit a photo, bookmarks will not be created between a photo and a collection if a bookmark between the two already exists.