### PR TITLE
Add photos new collection

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -43,9 +43,17 @@ class CollectionsController < ApplicationController
   end
 
   def set_cover
+    @photos = Photo.all
+    request.variant = :turbo_stream
     @collection = Collection.find(params[:collection_id])
     @collection.cover = params[:photo_id]
     @collection.save!
+
+
+     respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
   end
 
   def update

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -15,12 +15,7 @@ class CollectionsController < ApplicationController
     @collection = Collection.new(collection_params)
     authorize @collection
     if @collection.save!
-      params[:collection][:photo_ids].delete("")
-      params[:collection][:photo_ids].each do |photo|
-        @bookmark = Bookmark.new(photo_id: photo.to_i, collection: @collection)
-        @bookmark.save!
-      end
-      redirect_to collection_path(@collection)
+      redirect_to edit_collection_path(@collection)
     else
       render :new
     end

--- a/app/views/collections/_coverphoto.html.erb
+++ b/app/views/collections/_coverphoto.html.erb
@@ -1,0 +1,3 @@
+<% if @collection.cover != nil %>
+  <%= cl_image_tag @photos.find(id = @collection.cover).photo.key %>
+<% end %>

--- a/app/views/collections/_editshow.html.erb
+++ b/app/views/collections/_editshow.html.erb
@@ -9,7 +9,11 @@
     <ul>
       <li><%= link_to "Edit", edit_photo_path(bookmark.photo.id) %></li>
       <li><%= link_to "Remove", bookmark_path(@collection.bookmark_ids[i], collection_id: @collection.id), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %></li>
-      <li><%= link_to "Set as cover photo", collection_set_cover_path(collection_id: @collection.id, photo_id: bookmark.photo_id), method: :set_cover %></li>
+      <% if bookmark.photo_id == @collection.cover %>
+        <li>Is set as cover photo</li>
+      <% else %>
+        <li><%= link_to "Set as cover photo", collection_set_cover_path(collection_id: @collection.id, photo_id: bookmark.photo_id), data: {turbo_stream: :set_cover} %></li>
+      <% end %>
     </ul>
   <% end %>
 <% end %>

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,7 +1,8 @@
 <%= turbo_stream_from "editshow" %>
 
-<h2>Cover photo</h2>
-<%= cl_image_tag @photos.find(id = @collection.cover).photo.key %>
+<%= turbo_frame_tag "coverphoto" do %>
+  <%= render "coverphoto" %>
+<% end %>
 
 <h1>Edit Album Title or Description</h1>
 <%= simple_form_for @collection do |f| %>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -2,7 +2,5 @@
 <%= simple_form_for @collection do |f| %>
   <%= f.input :name %>
     <%= f.input :description %>
-<h2>Add photos to your album:</h2>
-  <%= f.association :photos %>
   <%= f.button :submit, "Create" %>
 <% end %>

--- a/app/views/collections/set_cover.erb
+++ b/app/views/collections/set_cover.erb
@@ -1,3 +1,0 @@
-<% turbo_stream.update "show_collection_edit" do %>
-  <%= render "collections/editshow", collection: params[:collection_id] %>
-<% end %>

--- a/app/views/collections/set_cover.turbo_stream.erb
+++ b/app/views/collections/set_cover.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.update "coverphoto" do %>
+  <%= render "coverphoto", collection: params[:collection_id] %>
+<% end %>
+
+<%= turbo_stream.update "show_collection_edit" do %>
+  <%= render "collections/editshow", collection: params[:collection_id] %>
+<% end %>


### PR DESCRIPTION
After building the edit page to allow AJAX I figured we could reuse it for new collections.
I tried adding the add photo function to the new page itself, but it doesn't work since the collection has yet to be saved.

What I have done here is redirect the user to the edit page for the new collection so that as soon as they create an album they can start adding photos/set cover image.

Empty collections and Collections without covers should no longer cause any sort of errors.

Let me know if this solution looks okay!
